### PR TITLE
Define no dependencies

### DIFF
--- a/scribe-plugin-sanitizer.js
+++ b/scribe-plugin-sanitizer.js
@@ -1,7 +1,7 @@
 // UMD
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define('html-janitor',factory);
+    define('html-janitor', [], factory);
   } else {
     root.amdWeb = factory();
   }


### PR DESCRIPTION
I don't think that [by standard](http://requirejs.org/docs/whyamd.html#namedmodules) you can omit dependencies? At least it breaks our loader.