### PR TITLE
Update scribe-plugin-sanitizer.js

### DIFF
--- a/src/scribe-plugin-sanitizer.js
+++ b/src/scribe-plugin-sanitizer.js
@@ -21,7 +21,7 @@ define([
     // content through this sanitizer.
     var configAllowMarkers = merge(cloneDeep(config), {
       tags: {
-        em: {class: 'scribe-marker'}
+        em: {'class': 'scribe-marker'}
       }
     });
 


### PR DESCRIPTION
'Class' variable is restricted -> throws an error in IE9
