### PR TITLE
Dependencies: update Lodash to 3.5.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "scribe-plugin-sanitizer",
   "dependencies": {
     "html-janitor": "0.3.0",
-    "lodash-amd": "2.4.1"
+    "lodash-amd": "3.5.0"
   },
   "version": "0.1.5"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "src/scribe-plugin-sanitizer.js",
   "dependencies": {
     "html-janitor": "~0.2.0",
-    "lodash-amd": "~2.4.1"
+    "lodash-compat": "~3.5.0"
   },
   "devDependencies": {
     "plumber": "~0.4.0",

--- a/src/scribe-plugin-sanitizer.js
+++ b/src/scribe-plugin-sanitizer.js
@@ -1,7 +1,7 @@
 define([
   'html-janitor',
-  'lodash-amd/modern/objects/merge',
-  'lodash-amd/modern/objects/cloneDeep'
+  'lodash-amd/modern/object/merge',
+  'lodash-amd/modern/lang/cloneDeep'
 ], function (
   HTMLJanitor,
   merge,


### PR DESCRIPTION
Deals with #16, ideally the first step in updating Lodash across Scribe and related plugins