### PR TITLE
Update HTMLJanitor and fix lodash paths

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,8 @@
 {
   "name": "scribe-plugin-sanitizer",
   "dependencies": {
-    "html-janitor": "0.3.0",
+    "html-janitor": "^1.0.1",
     "lodash-amd": "3.5.0"
   },
-  "version": "0.1.5"
+  "version": "0.1.9"
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "scribe-plugin-sanitizer",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "main": "src/scribe-plugin-sanitizer.js",
   "dependencies": {
-    "html-janitor": "~0.2.0",
+    "html-janitor": "^1.0.1",
     "lodash-amd": "~3.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR fixes two issues:

1. The recent lodash upgrade changed from `lodash-amd` to `lodash-compat`, however in the source file `lodash-amd` was still referenced.
2. The version of `html-janitor` being used was out of date and the new version provides a better UMD version, so I updated it. This was necessary to use in non-AMD environments like CommonJS.

Any potential issues you see here?