### PR TITLE
Quoting 'class' property

### DIFF
--- a/src/scribe-plugin-sanitizer.js
+++ b/src/scribe-plugin-sanitizer.js
@@ -22,7 +22,7 @@ define([
     // browser to ensure elements are selectable.
     var configAllowMarkers = merge(cloneDeep(config), {
       tags: {
-        em: {class: 'scribe-marker'},
+        em: {'class': 'scribe-marker'},
         br: {}
       }
     });


### PR DESCRIPTION
Fix for Android 4 returning an "Unexpected syntaxError reserved word"